### PR TITLE
Fix klarna params not found on payment admin

### DIFF
--- a/lib/klarna_gateway/controllers/admin/payment_methods_controller.rb
+++ b/lib/klarna_gateway/controllers/admin/payment_methods_controller.rb
@@ -9,16 +9,16 @@ module KlarnaGateway
 
       def validate_klarna_credentials
         if params[:payment_method][:type] == 'Spree::Gateway::KlarnaCredit'
-          if (params[:gateway_klarna_credit][:preferred_api_secret].blank? || params[:gateway_klarna_credit][:preferred_api_key].blank?)
+          if (params[:payment_method][:preferred_api_secret].blank? || params[:payment_method][:preferred_api_key].blank?)
             flash[:error] = Spree.t('klarna.can_not_test_api_connection')
           end
 
-          if params[:gateway_klarna_credit][:preferred_api_secret].present? && params[:gateway_klarna_credit][:preferred_api_key].present?
+          if params[:payment_method][:preferred_api_secret].present? && params[:payment_method][:preferred_api_key].present?
             Klarna.configure do |config|
               config.environment = !Rails.env.production? ? 'test' : 'production'
-              config.country = params[:gateway_klarna_credit][:preferred_country]
-              config.api_key =  params[:gateway_klarna_credit][:preferred_api_key]
-              config.api_secret = params[:gateway_klarna_credit][:preferred_api_secret]
+              config.country = params[:payment_method][:preferred_country]
+              config.api_key =  params[:payment_method][:preferred_api_key]
+              config.api_secret = params[:payment_method][:preferred_api_secret]
               config.user_agent = "Klarna Solidus Gateway/#{::KlarnaGateway::VERSION} Solidus/#{::Spree.solidus_version} Rails/#{::Rails.version}"
             end
 


### PR DESCRIPTION
On solidus 2.9, the admin payment_method controller was failing.